### PR TITLE
Fix type in example

### DIFF
--- a/src/Svg/Events.elm
+++ b/src/Svg/Events.elm
@@ -33,7 +33,7 @@ import VirtualDom
 
     import Json.Decode as Json
 
-    onClick : msg -> Property msg
+    onClick : msg -> Attribute msg
     onClick msg =
       on "click" (Json.succeed msg)
 


### PR DESCRIPTION
Technically, `Property` is also correct, due to type aliasing, but type `Property` is nowhere else brought to the attention of the library user. In particular, the type of `on` is itself given with return type `Attribute`, so it makes no sense to assign return type `Property` to the example code meant to explain the use of `on`.