### PR TITLE
Add Svg namespace to Svg.Keyed.node

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "summary": "Fast SVG, rendered with virtual DOM diffing",
     "repository": "https://github.com/elm-lang/svg.git",
     "license": "BSD3",

--- a/src/Svg/Keyed.elm
+++ b/src/Svg/Keyed.elm
@@ -1,4 +1,5 @@
-module Svg.Keyed exposing ( node )
+module Svg.Keyed exposing (node)
+
 {-| A keyed node helps optimize cases where children are getting added, moved,
 removed, etc. Common examples include:
 
@@ -15,7 +16,7 @@ efficiently.
 
 -}
 
-
+import Json.Encode as Json
 import Svg exposing (Attribute, Svg)
 import VirtualDom
 
@@ -26,5 +27,10 @@ nodes, removing nodes, etc. In these cases, the unique identifiers help make
 the DOM modifications more efficient.
 -}
 node : String -> List (Attribute msg) -> List ( String, Svg msg ) -> Svg msg
-node =
-  VirtualDom.keyedNode
+node name attributes =
+    VirtualDom.keyedNode name (svgNamespace :: attributes)
+
+
+svgNamespace : Attribute msg
+svgNamespace =
+    VirtualDom.property "namespace" (Json.string "http://www.w3.org/2000/svg")


### PR DESCRIPTION
This fixes https://github.com/elm-lang/svg/issues/5. I have tested it against the example given in that issue.

NB: I ran elm-format when composing the code and it modified the module-header line slightly.

@evancz This is the PR you suggested on the elm-dev list.