### PR TITLE
fix some incorrect SVG tags

### DIFF
--- a/src/Svg.elm
+++ b/src/Svg.elm
@@ -214,7 +214,7 @@ mask =
 {-|-}
 missingGlyph : List (Attribute msg) -> List (Svg msg) -> Svg msg
 missingGlyph =
-  node "missingGlyph"
+  node "missing-glyph"
 
 
 {-|-}
@@ -400,31 +400,31 @@ font =
 {-|-}
 fontFace : List (Attribute msg) -> List (Svg msg) -> Svg msg
 fontFace =
-  node "fontFace"
+  node "font-face"
 
 
 {-|-}
 fontFaceFormat : List (Attribute msg) -> List (Svg msg) -> Svg msg
 fontFaceFormat =
-  node "fontFaceFormat"
+  node "font-face-format"
 
 
 {-|-}
 fontFaceName : List (Attribute msg) -> List (Svg msg) -> Svg msg
 fontFaceName =
-  node "fontFaceName"
+  node "font-face-name"
 
 
 {-|-}
 fontFaceSrc : List (Attribute msg) -> List (Svg msg) -> Svg msg
 fontFaceSrc =
-  node "fontFaceSrc"
+  node "font-face-src"
 
 
 {-|-}
 fontFaceUri : List (Attribute msg) -> List (Svg msg) -> Svg msg
 fontFaceUri =
-  node "fontFaceUri"
+  node "font-face-uri"
 
 
 {-|-}


### PR DESCRIPTION
missingGlyph -> missing-glyph
fontFace -> font-face
fontFaceFormat -> font-face-format
fontFaceName -> font-face-name
fontFaceSrc -> font-face-src
fontFaceUri -> font-face-uri
