### PR TITLE
README.md link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SVG in Elm
 
-Use SVG in Elm.
+Use SVG in Elm. Please see the [API Documentation](http://package.elm-lang.org/packages/elm-lang/svg/latest) for details.
 
 This library is built on [elm-lang/virtual-dom](http://package.elm-lang.org/packages/elm-lang/virtual-dom/latest/) which handles the dirty details of rendering things quickly.
 


### PR DESCRIPTION
 - added link to the documentation, it's a bit confusing that there is
   only one doc link which links to a different package (virtual-dom)